### PR TITLE
Implemented cascades with an evaluated closure

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ dependencies {
 ```
 
 Here is an example of a command object that uses the plugin:
+```groovy
+class Person implements Validateable {
+    String firstName
+    String lastName
+    List<PhoneNumber> phones
+    
+    static constraints = {
+        phones cascaded: { value -> value.isPrimary } // Only validate the phonenumber if the value is a primary number
+    }
+}
+```
+
 
 ```groovy
  class PhoneNumber implements Validateable {

--- a/src/main/asciidoc/3. usage.adoc
+++ b/src/main/asciidoc/3. usage.adoc
@@ -3,8 +3,29 @@
 ifndef::src[:src: ../../../]
 ifndef::example[:example: {src}/cascade-validation-example]
 
-This section demonstrates how to apply the plugin's constraint in domain classes and how to invoke validation from services and tests.
-The example code below is representative — replace the placeholders with the code from the example project in this repository if you want verbatim examples.
+== General usage
+
+The constraint can be applied in two ways, either as `cascaded: true` or as a `Closure<Boolean>`:
+
+[source,groovy]
+----
+class Person {
+    Address address
+    List<Phone> phones
+    boolean shouldValidatePhones
+    static constraints = { 
+      // Will enable cascade for the Address property
+      address cascaded: true 
+      // Will enable cascade for all phone numbers if `shouldValidatePhones` is true
+      phones cascaded: { property, target -> 
+        target.shouldValidatePhones 
+      }
+    }
+}
+----
+
+
+Another example can be found in `ValidateableParent` below.
 
 == Domain example
 

--- a/src/main/groovy/grails/cascade/validation/internal/CascadeConstraint.groovy
+++ b/src/main/groovy/grails/cascade/validation/internal/CascadeConstraint.groovy
@@ -21,20 +21,22 @@ import org.springframework.validation.FieldError
  */
 @CompileStatic
 class CascadeConstraint extends AbstractConstraint {
-    boolean enabled = true
 
     static final String CASCADE_CONSTRAINT = "cascaded"
+    private final Closure<Boolean> enabledEvaluator
 
     CascadeConstraint(Class<?> constraintOwningClass, String constraintPropertyName, Object constraintParameter, MessageSource messageSource) {
         super(constraintOwningClass, constraintPropertyName, constraintParameter, messageSource)
-
-        this.enabled = (boolean) constraintParameter
+        this.enabledEvaluator = constraintParameter instanceof Closure ? (constraintParameter as Closure<Boolean>) : { (constraintParameter as boolean) }
+        if(this.enabledEvaluator.maximumNumberOfParameters > 2) {
+            throw new IllegalArgumentException("Too many arguments on closure, expects one or two")
+        }
     }
 
     @Override
     protected Object validateParameter(Object constraintParameter) {
-        if (!(constraintParameter instanceof Boolean)) {
-            throw new IllegalArgumentException("Parameter for constraint [$CASCADE_CONSTRAINT] of property [$constraintPropertyName] of class [$constraintOwningClass] must be a boolean")
+        if (!(constraintParameter instanceof Boolean || constraintParameter instanceof Closure)) {
+            throw new IllegalArgumentException("Parameter for constraint [$CASCADE_CONSTRAINT] of property [$constraintPropertyName] of class [$constraintOwningClass] must be a boolean or a closure returning a boolean")
         }
         return constraintParameter
     }
@@ -48,6 +50,10 @@ class CascadeConstraint extends AbstractConstraint {
     }
 
     protected void processValidate(Object target, Object propertyValue, Errors errors) {
+        if (!isEnabled(target, propertyValue)) {
+            return
+        }
+
         if (propertyValue instanceof Collection) {
             propertyValue.eachWithIndex { item, pvIdx ->
                 validateValue(target, item, errors, pvIdx)
@@ -56,6 +62,7 @@ class CascadeConstraint extends AbstractConstraint {
             validateValue(target, propertyValue, errors)
         }
     }
+
 
     /**
      * Processes the validation of the propertyValue, against the checks patterns set, and setting and calling rejectValue
@@ -90,6 +97,14 @@ class CascadeConstraint extends AbstractConstraint {
 
             FieldError fieldError = new FieldError(objectName, field, childFieldError.rejectedValue, childFieldError.bindingFailure, childFieldError.codes, childFieldError.arguments, childFieldError.defaultMessage)
             errors.addError(fieldError)
+        }
+    }
+
+    private boolean isEnabled(Object target, Object propertyValue) {
+        switch(enabledEvaluator.maximumNumberOfParameters) {
+            case 1: return enabledEvaluator.call(propertyValue)
+            case 2: return enabledEvaluator.call(propertyValue, target)
+            default: throw new IllegalArgumentException("Too many arguments on closure, expects one or two")
         }
     }
 

--- a/src/test/groovy/grails/cascade/validation/CascadeValidationConstraintSpec.groovy
+++ b/src/test/groovy/grails/cascade/validation/CascadeValidationConstraintSpec.groovy
@@ -13,9 +13,10 @@ import spock.lang.Specification
  * @author Eric Kelm
  */
 class CascadeValidationConstraintSpec extends Specification {
+
     CascadeConstraint constraint
     ValidateableParent parent
-    ValidationErrors errors
+    ValidationErrors errors = Mock()
 
     def setup() {
         parent = Mock(ValidateableParent)
@@ -23,7 +24,7 @@ class CascadeValidationConstraintSpec extends Specification {
         parent.errors >> errors
     }
 
-    def "constraint name should be cascade"() {
+    void "constraint name should be cascade"() {
         given:
         constraint = new CascadeConstraint(
                 ValidateableParent,
@@ -36,7 +37,7 @@ class CascadeValidationConstraintSpec extends Specification {
         constraint.name == 'cascaded'
     }
 
-    def "validateWithVetoing fails when constraint is set on non-validatable type"() {
+    void "validateWithVetoing fails when constraint is set on non-validatable type"() {
         given:
         constraint = new CascadeConstraint(
                 ValidateableParent,
@@ -54,7 +55,7 @@ class CascadeValidationConstraintSpec extends Specification {
         thrown(NoSuchMethodException)
     }
 
-    def "validateWithVetoing returns valid when constraint is set to validateable type and constraints pass"() {
+    void "validateWithVetoing returns valid when constraint is set to validateable type and constraints pass"() {
         given:
         constraint = new CascadeConstraint(
                 ValidateableParent,
@@ -73,7 +74,7 @@ class CascadeValidationConstraintSpec extends Specification {
         0 * errors.addError(_)
     }
 
-    def "validateWithVetoing returns invalid when constraint is set to validateable type and constraints fail"() {
+    void "validateWithVetoing returns invalid when constraint is set to validateable type and constraints fail"() {
         given:
         constraint = new CascadeConstraint(
                 ValidateableParent,
@@ -113,7 +114,7 @@ class CascadeValidationConstraintSpec extends Specification {
         })
     }
 
-    def "validateWithVetoing returns invalid when constraint is set to validateable type and constraints fail on list"() {
+    void "validateWithVetoing returns invalid when constraint is set to validateable type and constraints fail on list"() {
         given:
         constraint = new CascadeConstraint(
                 ValidateableParent,
@@ -151,7 +152,38 @@ class CascadeValidationConstraintSpec extends Specification {
         2 * errors.addError(_)
     }
 
-    def "constraint does not support non-validateable types"() {
+    void "constraint only validates if enabled evaluates to true"() {
+        given:
+        constraint = new CascadeConstraint(
+                ValidateableParent,
+                'anotherProperty',
+                truth,
+                null
+        )
+        parent.shouldCascade() >> shouldCascade
+
+        and:
+        def target = Mock(ValidateableProperty)
+
+        when:
+        constraint.validate(parent, target, errors)
+
+        then:
+        callsToValidate * target.validate() >> true
+
+        where:
+        _ | truth                                 | shouldCascade || callsToValidate
+        _ | true                                  | _             || 1
+        _ | false                                 | _             || 0
+        _ | { true }                              | _             || 1
+        _ | { false }                             | _             || 0
+        _ | { val -> true }                       | _             || 1
+        _ | { val -> false }                      | _             || 0
+        _ | { value, obj -> obj.shouldCascade() } | true          || 1
+        _ | { value, obj -> obj.shouldCascade() } | false         || 0
+    }
+
+    void "constraint does not support non-validateable types"() {
         given:
         constraint = new CascadeConstraint(
                 ValidateableParent,
@@ -164,7 +196,7 @@ class CascadeValidationConstraintSpec extends Specification {
         !constraint.supports(String)
     }
 
-    def "constraint supports validateable types"() {
+    void "constraint supports validateable types"() {
         given:
         constraint = new CascadeConstraint(
                 ValidateableParent,
@@ -177,7 +209,7 @@ class CascadeValidationConstraintSpec extends Specification {
         constraint.supports(ValidateableProperty)
     }
 
-    def "constraint supports collection types"() {
+    void "constraint supports collection types"() {
         given:
         constraint = new CascadeConstraint(
                 ValidateableParent,
@@ -190,7 +222,37 @@ class CascadeValidationConstraintSpec extends Specification {
         constraint.supports(List)
     }
 
-    def "constraint cannot handle constraintParameter other than boolean"() {
+    void "constraint can handle constraintParameter when is a closure with one or two params"() {
+        when:
+        constraint = new CascadeConstraint(
+                ValidateableParent,
+                'property',
+                closure,
+                null
+        )
+
+        then:
+        notThrown IllegalArgumentException
+
+        where:
+        closure << [{ return true }, { a -> return true }, { a, b -> return true }]
+    }
+
+    void "constraint cannot handle constraintParameter when is a closure more than two parameters"() {
+        when:
+        constraint = new CascadeConstraint(
+                ValidateableParent,
+                'property',
+                { a, b, c -> true },
+                null
+        )
+
+        then:
+        def e = thrown IllegalArgumentException
+        e.message == 'Too many arguments on closure, expects one or two'
+    }
+
+    void "constraint cannot handle constraintParameter other than boolean"() {
         when:
         constraint = new CascadeConstraint(
                 ValidateableParent,

--- a/src/test/groovy/grails/cascade/validation/support/ValidateableParent.groovy
+++ b/src/test/groovy/grails/cascade/validation/support/ValidateableParent.groovy
@@ -6,9 +6,13 @@ import grails.validation.Validateable
 class ValidateableParent implements Validateable {
 
     ValidateableProperty property
-
+    ValidateableProperty anotherProperty
+    
+    boolean shouldCascade() { true }
+    
     static constraints = {
         property cascaded: true
+        anotherProperty cascade: { value, object -> object.shouldCascade() }
     }
 }
 // end::code[]


### PR DESCRIPTION
This pull request enhances the flexibility of the `cascaded` constraint in the Grails cascade validation plugin, allowing it to be conditionally enabled using closures as well as booleans. The documentation and tests have been updated to reflect and verify this new functionality, and the implementation has been refactored to support closures with one or two parameters for more dynamic validation scenarios.

**Constraint flexibility and implementation:**
- The `CascadeConstraint` now accepts either a boolean or a closure (with up to two parameters) as its enabling parameter, allowing conditional cascade validation based on runtime logic. An error is thrown if a closure with more than two parameters is provided. [[1]](diffhunk://#diff-d6510c32f2ea3ef5590c3781c6717c0dd54b52014a09b1090b1c3d3764a45080L24-R39) [[2]](diffhunk://#diff-d6510c32f2ea3ef5590c3781c6717c0dd54b52014a09b1090b1c3d3764a45080R103-R110)
- The validation process now checks if the constraint is enabled by evaluating the closure or boolean before proceeding.

**Example and support classes:**
- The `ValidateableParent` test support class now includes an example property and constraint using the new closure-based enabling pattern.
 
Fixes #9