### PR TITLE
refactor: Rename classes Cascade* to Cascaded*

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,3 +66,4 @@ tasks.withType(Test).configureEach {
 }
 
 apply from: layout.projectDirectory.file('gradle/docs-config.gradle')
+apply from: layout.projectDirectory.file('gradle/post-publish.gradle')

--- a/cascade-validation-example/src/test/groovy/cascade/PersonCascadeSpec.groovy
+++ b/cascade-validation-example/src/test/groovy/cascade/PersonCascadeSpec.groovy
@@ -1,8 +1,9 @@
 package cascade
 
 
-import grails.cascade.validation.internal.CascadeConstraintRegistration
+import grails.cascade.validation.internal.CascadedConstraintRegistration
 import grails.testing.gorm.DataTest
+import grails.util.Holders
 import spock.lang.Specification
 
 class PersonCascadeSpec extends Specification implements DataTest {
@@ -11,8 +12,10 @@ class PersonCascadeSpec extends Specification implements DataTest {
         mockDomains(Person, PhoneNumber, TelephoneType)
         // Important in unit-tests: Register the CascadeConstraints
         // tag::initialize[]
-        CascadeConstraintRegistration.register(applicationContext)
+        CascadedConstraintRegistration.register(applicationContext)
         // end::initialize[]
+        // Default
+        Holders.config.setAt('constraints.cascaded.legacy', false)
     }
 
     void "cascade validation on Person with empty phoneNumbers"() {
@@ -38,6 +41,25 @@ class PersonCascadeSpec extends Specification implements DataTest {
         person.errors.getFieldError('phoneNumbers[0].telephoneType').code == 'nullable'
     }    
     
+    void "cascade validation on Person with non-valid phoneNumber in phoneNumbers (legacy)"() {
+        given:
+        Holders.config.setAt('constraints.cascaded.legacy', true)
+
+        and: 
+        Person person = new Person(firstName: 'John', lastName: 'Doe').tap {
+            addToPhoneNumbers(countryCode: '+1', areaCode: '800', number: '555-2345')
+        }
+        
+        expect: 'that the validation fails due to errors in the phone-number'
+        !person.validate()
+        
+        and: 'there is one error in the phone-number'
+        person.errors.errorCount == 2 // Also has the Gorm cascade validation errors
+        
+        and:  'that error is on the first phone-number telephone-type'
+        person.errors.getFieldError('phoneNumbers.0.telephoneType').code == 'nullable'
+    }    
+    
     void "cascade validation on Person with multiple non-valid phoneNumbers in phoneNumbers"() {
         given:
         Person person = new Person(firstName: 'John', lastName: 'Doe').tap {
@@ -49,12 +71,34 @@ class PersonCascadeSpec extends Specification implements DataTest {
         !person.validate()
         
         and: 'there are two error in the list of phone numbers'
-        person.errors.errorCount == 2
+        person.errors.errorCount == 3 // Due to GORM cascade validations
         
         and:  'that error is on the first phone number telephone type'
         person.errors.getFieldError('phoneNumbers[0].telephoneType').code == 'nullable'
 
         and: 'the error on the second phone number is cascading to telephoneType'
         person.errors.getFieldError('phoneNumbers[1].telephoneType.countryCodeRecommended').code == 'nullable'
+    }  
+    
+    void "cascade validation on Person with multiple non-valid phoneNumbers in phoneNumbers (legacy)"() {
+        given:
+        Holders.config.setAt('constraints.cascaded.legacy', true)
+        and:
+        Person person = new Person(firstName: 'John', lastName: 'Doe').tap {
+            addToPhoneNumbers(countryCode: '+1', areaCode: '800', number: '555-2345')
+            addToPhoneNumbers(countryCode: '+1', areaCode: '800', number: '555-1234', telephoneType: new TelephoneType())
+        }
+        
+        expect: 'that the validation fails due to errors in the phone-number'
+        !person.validate()
+        
+        and: 'there are two error in the list of phone numbers'
+        person.errors.errorCount == 5 // Due to GORM cascade validations
+        
+        and:  'that error is on the first phone number telephone type'
+        person.errors.getFieldError('phoneNumbers.0.telephoneType').code == 'nullable'
+
+        and: 'the error on the second phone number is cascading to telephoneType'
+        person.errors.getFieldError('phoneNumbers.1.telephoneType.countryCodeRecommended').code == 'nullable'
     }
 }

--- a/gradle/post-publish.gradle
+++ b/gradle/post-publish.gradle
@@ -1,0 +1,12 @@
+tasks.register('printPublicationInfo') {
+    group = 'publishing'
+    doLast {
+        publishing.publications.each { pub ->
+            logger.lifecycle  "📦 ${pub.name}: ${pub.groupId}:${pub.artifactId}:${pub.version}"
+        }
+    }
+}
+
+tasks.withType(AbstractPublishToMaven).configureEach {
+    finalizedBy(tasks.named('printPublicationInfo'))
+}

--- a/src/main/asciidoc/1. introduction.adoc
+++ b/src/main/asciidoc/1. introduction.adoc
@@ -3,9 +3,21 @@
 The Cascade Validation Plugin provides a small, focused extension to Grails constraints that makes it easy to validate associated objects (domain associations or command object) as part of normal validation.
 Instead of manually calling validate() on every association, the plugin supplies a constraint (see usage) that marks an association to be validated automatically.
 
-== Breaking change.
+== Breaking changes.
 
 Due to a change in Hibernate, there is a name clash with the `cascade` constraint keyword.
 For this reason `cascade` was renamed to  `cascaded`.
 Please update all your domain and command classes accordingly.
-Search for `cascade: true` (or `cascade: false`) and replace with `cascaded: true` (or `false`).  
+Search for `cascade: true` (or `cascade: false`) and replace with `cascaded: true` (or `false`). 
+
+The constraint class was renamed from `CascadeConstraint` to `CascadedConstraint` and the registration class from `CascadeConstraintRegistration` to `CascadedConstraintRegistration` 
+
+The previous format for the `field` name on collections was `field.0.childProperty`, but since 
+Grails 7 does cascade validations on Domain objects, and the format for errors in this validation is `field[0].childProperty` a configuration property was added, to control if the legacy format should be used, or if the new format is used:
+
+[source,yaml]
+----
+constraints:
+    cascaded:
+        legacy: true # default to false
+----

--- a/src/main/asciidoc/3. usage.adoc
+++ b/src/main/asciidoc/3. usage.adoc
@@ -67,7 +67,7 @@ include::{example}/src/integration-test/groovy/cascade/PersonDataServiceSpec.gro
 
 == Databinding usage
 
-When binding data to  `grails.validation.Validateable` objects (e.g., via controllers or REST endpoints), call `validate()` or rely on automatic validation in data-binding flows, the `CascadeConstraint` ensures marked associations are validated as part of the root object validation.
+When binding data to  `grails.validation.Validateable` objects (e.g., via controllers or REST endpoints), call `validate()` or rely on automatic validation in data-binding flows, the `CascadedConstraint` ensures marked associations are validated as part of the root object validation.
 
 This can be illustrated with two examples:
 

--- a/src/main/groovy/grails/cascade/validation/CascadeValidationGrailsPlugin.groovy
+++ b/src/main/groovy/grails/cascade/validation/CascadeValidationGrailsPlugin.groovy
@@ -1,7 +1,7 @@
 package grails.cascade.validation
 
 
-import grails.cascade.validation.internal.CascadeConstraintRegistration
+import grails.cascade.validation.internal.CascadedConstraintRegistration
 import grails.plugins.Plugin
 
 class CascadeValidationGrailsPlugin extends Plugin {
@@ -38,7 +38,7 @@ Used with permission.
 
 
     void doWithApplicationContext() {
-        CascadeConstraintRegistration.register(applicationContext)
+        CascadedConstraintRegistration.register(applicationContext)
     }
 
 }

--- a/src/main/groovy/grails/cascade/validation/internal/CascadedConstraint.groovy
+++ b/src/main/groovy/grails/cascade/validation/internal/CascadedConstraint.groovy
@@ -1,6 +1,6 @@
 package grails.cascade.validation.internal
 
-
+import grails.util.Holders
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import org.grails.datastore.gorm.validation.constraints.AbstractConstraint
@@ -20,12 +20,12 @@ import org.springframework.validation.FieldError
  * @author Russell Morrisey
  */
 @CompileStatic
-class CascadeConstraint extends AbstractConstraint {
+class CascadedConstraint extends AbstractConstraint {
 
     static final String CASCADE_CONSTRAINT = "cascaded"
     private final Closure<Boolean> enabledEvaluator
 
-    CascadeConstraint(Class<?> constraintOwningClass, String constraintPropertyName, Object constraintParameter, MessageSource messageSource) {
+    CascadedConstraint(Class<?> constraintOwningClass, String constraintPropertyName, Object constraintParameter, MessageSource messageSource) {
         super(constraintOwningClass, constraintPropertyName, constraintParameter, messageSource)
         this.enabledEvaluator = constraintParameter instanceof Closure ? (constraintParameter as Closure<Boolean>) : { (constraintParameter as boolean) }
         if(this.enabledEvaluator.maximumNumberOfParameters > 2) {
@@ -90,7 +90,7 @@ class CascadeConstraint extends AbstractConstraint {
             String field
 
             if (index != null) {
-                field = "${propertyName}.${index}.${childFieldError.field}"
+                field = useLegacyNaming ? "${propertyName}.${index}.${childFieldError.field}" : "${propertyName}[${index}].${childFieldError.field}"
             } else {
                 field = "${propertyName}.${childFieldError.field}"
             }
@@ -98,6 +98,10 @@ class CascadeConstraint extends AbstractConstraint {
             FieldError fieldError = new FieldError(objectName, field, childFieldError.rejectedValue, childFieldError.bindingFailure, childFieldError.codes, childFieldError.arguments, childFieldError.defaultMessage)
             errors.addError(fieldError)
         }
+    }
+    
+    private static boolean getUseLegacyNaming() {
+        Holders.config?.getProperty('constraints.cascaded.legacy', Boolean, Boolean.FALSE)
     }
 
     private boolean isEnabled(Object target, Object propertyValue) {

--- a/src/main/groovy/grails/cascade/validation/internal/CascadedConstraintRegistration.groovy
+++ b/src/main/groovy/grails/cascade/validation/internal/CascadedConstraintRegistration.groovy
@@ -9,8 +9,9 @@ import org.grails.datastore.mapping.validation.ValidatorRegistry
 import org.springframework.context.ApplicationContext
 
 @Slf4j
-class CascadeConstraintRegistration {
+class CascadedConstraintRegistration {
     static void register(ApplicationContext applicationContext) {
+        
         registerCascadeConstraintOnBeans(applicationContext, ConstraintsEvaluator, DefaultConstraintEvaluator) {
             it.constraintRegistry
         }
@@ -26,7 +27,7 @@ class CascadeConstraintRegistration {
         evaluators.each { name, evaluator ->
             if (clazz.isAssignableFrom(evaluator.getClass())) {
                 ConstraintRegistry reg = closure.call(evaluator)
-                reg.addConstraint(CascadeConstraint)
+                reg.addConstraint(CascadedConstraint)
             }
             log.debug("Registered CascadeConstraint on $name evaluator on $interfaceClass")
         }

--- a/src/test/groovy/grails/cascade/validation/CascadeValidationConstraintSpec.groovy
+++ b/src/test/groovy/grails/cascade/validation/CascadeValidationConstraintSpec.groovy
@@ -1,9 +1,10 @@
 package grails.cascade.validation
 
-import grails.cascade.validation.internal.CascadeConstraint
+import grails.cascade.validation.internal.CascadedConstraint
 import grails.cascade.validation.support.ValidateableParent
 import grails.cascade.validation.support.ValidateableProperty
 import grails.validation.ValidationErrors
+import org.grails.testing.GrailsUnitTest
 import org.springframework.validation.Errors
 import org.springframework.validation.FieldError
 import spock.lang.Specification
@@ -12,9 +13,9 @@ import spock.lang.Specification
  * @author: rmorrise
  * @author Eric Kelm
  */
-class CascadeValidationConstraintSpec extends Specification {
+class CascadeValidationConstraintSpec extends Specification implements GrailsUnitTest {
 
-    CascadeConstraint constraint
+    CascadedConstraint constraint
     ValidateableParent parent
     ValidationErrors errors = Mock()
 
@@ -26,7 +27,7 @@ class CascadeValidationConstraintSpec extends Specification {
 
     void "constraint name should be cascade"() {
         given:
-        constraint = new CascadeConstraint(
+        constraint = new CascadedConstraint(
                 ValidateableParent,
                 'property',
                 true,
@@ -39,7 +40,7 @@ class CascadeValidationConstraintSpec extends Specification {
 
     void "validateWithVetoing fails when constraint is set on non-validatable type"() {
         given:
-        constraint = new CascadeConstraint(
+        constraint = new CascadedConstraint(
                 ValidateableParent,
                 'property',
                 true,
@@ -57,7 +58,7 @@ class CascadeValidationConstraintSpec extends Specification {
 
     void "validateWithVetoing returns valid when constraint is set to validateable type and constraints pass"() {
         given:
-        constraint = new CascadeConstraint(
+        constraint = new CascadedConstraint(
                 ValidateableParent,
                 'property',
                 true,
@@ -76,7 +77,7 @@ class CascadeValidationConstraintSpec extends Specification {
 
     void "validateWithVetoing returns invalid when constraint is set to validateable type and constraints fail"() {
         given:
-        constraint = new CascadeConstraint(
+        constraint = new CascadedConstraint(
                 ValidateableParent,
                 'property',
                 true,
@@ -116,7 +117,7 @@ class CascadeValidationConstraintSpec extends Specification {
 
     void "validateWithVetoing returns invalid when constraint is set to validateable type and constraints fail on list"() {
         given:
-        constraint = new CascadeConstraint(
+        constraint = new CascadedConstraint(
                 ValidateableParent,
                 'property',
                 true,
@@ -154,7 +155,7 @@ class CascadeValidationConstraintSpec extends Specification {
 
     void "constraint only validates if enabled evaluates to true"() {
         given:
-        constraint = new CascadeConstraint(
+        constraint = new CascadedConstraint(
                 ValidateableParent,
                 'anotherProperty',
                 truth,
@@ -185,7 +186,7 @@ class CascadeValidationConstraintSpec extends Specification {
 
     void "constraint does not support non-validateable types"() {
         given:
-        constraint = new CascadeConstraint(
+        constraint = new CascadedConstraint(
                 ValidateableParent,
                 'property',
                 true,
@@ -198,7 +199,7 @@ class CascadeValidationConstraintSpec extends Specification {
 
     void "constraint supports validateable types"() {
         given:
-        constraint = new CascadeConstraint(
+        constraint = new CascadedConstraint(
                 ValidateableParent,
                 'property',
                 true,
@@ -211,7 +212,7 @@ class CascadeValidationConstraintSpec extends Specification {
 
     void "constraint supports collection types"() {
         given:
-        constraint = new CascadeConstraint(
+        constraint = new CascadedConstraint(
                 ValidateableParent,
                 'property',
                 true,
@@ -224,7 +225,7 @@ class CascadeValidationConstraintSpec extends Specification {
 
     void "constraint can handle constraintParameter when is a closure with one or two params"() {
         when:
-        constraint = new CascadeConstraint(
+        constraint = new CascadedConstraint(
                 ValidateableParent,
                 'property',
                 closure,
@@ -240,7 +241,7 @@ class CascadeValidationConstraintSpec extends Specification {
 
     void "constraint cannot handle constraintParameter when is a closure more than two parameters"() {
         when:
-        constraint = new CascadeConstraint(
+        constraint = new CascadedConstraint(
                 ValidateableParent,
                 'property',
                 { a, b, c -> true },
@@ -254,7 +255,7 @@ class CascadeValidationConstraintSpec extends Specification {
 
     void "constraint cannot handle constraintParameter other than boolean"() {
         when:
-        constraint = new CascadeConstraint(
+        constraint = new CascadedConstraint(
                 ValidateableParent,
                 'property',
                 ['x'],

--- a/src/test/groovy/grails/cascade/validation/CascadedConstraintRegistrationSpec.groovy
+++ b/src/test/groovy/grails/cascade/validation/CascadedConstraintRegistrationSpec.groovy
@@ -1,7 +1,7 @@
 package grails.cascade.validation
 
-import grails.cascade.validation.internal.CascadeConstraint
-import grails.cascade.validation.internal.CascadeConstraintRegistration
+import grails.cascade.validation.internal.CascadedConstraint
+import grails.cascade.validation.internal.CascadedConstraintRegistration
 import org.grails.datastore.gorm.validation.constraints.eval.ConstraintsEvaluator
 import org.grails.datastore.gorm.validation.constraints.eval.DefaultConstraintEvaluator
 import org.grails.datastore.gorm.validation.constraints.registry.ConstraintRegistry
@@ -13,7 +13,7 @@ import org.grails.spring.beans.factory.InstanceFactoryBean
 import org.grails.testing.GrailsUnitTest
 import spock.lang.Specification
 
-class CascadeConstraintRegistrationSpec extends Specification implements GrailsUnitTest {
+class CascadedConstraintRegistrationSpec extends Specification implements GrailsUnitTest {
 
     DefaultConstraintRegistry anotherConstraintRegistry = Mock()
     DefaultConstraintEvaluator defaultConstraintEvaluator = Spy(new DefaultConstraintEvaluator(anotherConstraintRegistry, Stub(MappingContext), Collections.emptyMap()))
@@ -29,16 +29,16 @@ class CascadeConstraintRegistrationSpec extends Specification implements GrailsU
         }
 
         when:
-        CascadeConstraintRegistration.register(applicationContext)
+        CascadedConstraintRegistration.register(applicationContext)
 
         then: 'cascading is added to DefaultConstraintEvaluator'
-        1 * anotherConstraintRegistry.addConstraint(CascadeConstraint)
+        1 * anotherConstraintRegistry.addConstraint(CascadedConstraint)
 
         and: 'cascading is added to DefaultValidatorRegistry'
-        1 * defaultValidatorRegistry.addConstraint(CascadeConstraint)
+        1 * defaultValidatorRegistry.addConstraint(CascadedConstraint)
 
         and: 'cascading is added to DefaultConstraintRegistry'
-        1 * defaultConstraintRegistry.addConstraint(CascadeConstraint)
+        1 * defaultConstraintRegistry.addConstraint(CascadedConstraint)
     }
 
     def "register with missing beans"() {
@@ -47,15 +47,15 @@ class CascadeConstraintRegistrationSpec extends Specification implements GrailsU
         }
 
         when:
-        CascadeConstraintRegistration.register(applicationContext)
+        CascadedConstraintRegistration.register(applicationContext)
 
         then: 'cascading is not added to DefaultConstraintEvaluator'
-        0 * anotherConstraintRegistry.addConstraint(CascadeConstraint)
+        0 * anotherConstraintRegistry.addConstraint(CascadedConstraint)
 
         and: 'cascading is not added to DefaultValidatorRegistry'
-        0 * defaultValidatorRegistry.addConstraint(CascadeConstraint)
+        0 * defaultValidatorRegistry.addConstraint(CascadedConstraint)
 
         and: 'cascading is not added to DefaultConstraintRegistry'
-        0 * defaultConstraintRegistry.addConstraint(CascadeConstraint)
+        0 * defaultConstraintRegistry.addConstraint(CascadedConstraint)
     }
 }


### PR DESCRIPTION
* The constraint name is determined by the class name (-Constraint)
* cascade clashes with Hibernate so name needs to be cascaded